### PR TITLE
Improve Python-WASM tests and Dating Show Notebook title/message layout

### DIFF
--- a/Code/2026/20260326_DatingShowNotebook/backend/index.ts
+++ b/Code/2026/20260326_DatingShowNotebook/backend/index.ts
@@ -419,6 +419,16 @@ export async function handleSSR(req: express.Request, res: express.Response) {
 
       let html = (template || '<!--ssr-outlet-->').replace(`<!--ssr-outlet-->`, appHtml);
 
+      if (initialPath) {
+        const parts = initialPath.split(/[\\/]/);
+        const lastPart = parts[parts.length - 1] || parts[parts.length - 2] || '';
+        const upperLetters = lastPart.replace(/[^A-Z]/g, '');
+        if (upperLetters) {
+          const newTitle = `${upperLetters} - Dating Show Notebook`;
+          html = html.replace(/<title>.*?<\/title>/, `<title>${newTitle}</title>`);
+        }
+      }
+
       if (initialData) {
         const combinedData = {
           data: initialData,

--- a/Code/2026/20260326_DatingShowNotebook/frontend/src/App.tsx
+++ b/Code/2026/20260326_DatingShowNotebook/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Routes, Route, useParams, useNavigate } from 'react-router-dom';
 import { useStore, fromSafeBase64, StoreContext, AppStore } from './store/useStore';
+import { getPageTitle } from './utils/layout';
 import NavigationPane from './components/NavigationPane';
 import TopButtonPane from './components/TopButtonPane';
 import MainBody from './components/MainBody';
@@ -37,6 +38,10 @@ const AppContent: React.FC = () => {
   const { selectedEpisodeId, currentFolderPath } = useStore((s) => {
     return { selectedEpisodeId: s.selectedEpisodeId, currentFolderPath: s.currentFolderPath };
   });
+
+  useEffect(() => {
+    document.title = getPageTitle(currentFolderPath);
+  }, [currentFolderPath]);
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-gray-100 text-gray-900">

--- a/Code/2026/20260326_DatingShowNotebook/frontend/src/components/MainBody.tsx
+++ b/Code/2026/20260326_DatingShowNotebook/frontend/src/components/MainBody.tsx
@@ -37,7 +37,6 @@ import {
 } from '../utils/layout';
 
 const DEBOUNCE_DELAY_MS = 1000;
-const MIN_DESC_ROWS = 2;
 const MSG_CENTER_DIVIDER = 2;
 
 const MARKER_WIDTH = 10;
@@ -685,7 +684,7 @@ const MainBody: React.FC = () => {
               }
 
               const { color, marker } = getMessageStyle(m.type, fromPos.gender);
-              const { x1, y1, x2, y2 } = calculateMessageCoords(fromPos, toPos, scale);
+              const { x1, y1, x2, y2 } = calculateMessageCoords(fromPos, toPos, scale, m.type);
 
               /**
                * Special Case: Intra-gender messages (Same gender)

--- a/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/layout.test.ts
+++ b/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/layout.test.ts
@@ -7,6 +7,7 @@ import {
   calculateMessageCoords,
   calculatTeamMemberCoords,
   wrapText,
+  getPageTitle,
 } from './layout';
 import { AppData, Person } from '../store/useStore';
 
@@ -114,6 +115,17 @@ describe('layout utils', () => {
       expect(coords.x1).toBe(110);
       expect(coords.y1).toBe(110);
     });
+
+    /* Verifies that bidirectional messages have horizontal offset but connect to the vertical middle. */
+    it('calculates bidirectional coords with horizontal offset only', () => {
+      const fromPos = { x: 100, y: 100, gender: 'male' as const };
+      const toPos = { x: 500, y: 100, gender: 'female' as const };
+      const coords = calculateMessageCoords(fromPos, toPos, 1, 'bidirectional');
+      expect(coords.x1).toBe(110);
+      expect(coords.y1).toBe(100);
+      expect(coords.x2).toBe(490);
+      expect(coords.y2).toBe(100);
+    });
   });
 
   describe('calculatTeamMemberCoords', () => {
@@ -144,6 +156,24 @@ describe('layout utils', () => {
       const lines = wrapText('ExtremelyLongWordThatExceedsWidth', 10, 16);
       expect(lines).toHaveLength(1);
       expect(lines[0]).toBe('ExtremelyLongWordThatExceedsWidth');
+    });
+  });
+
+  describe('getPageTitle', () => {
+    /* Tests the dynamic page title generation based on folder names. */
+    it('returns base title if folderPath is null', () => {
+      expect(getPageTitle(null)).toBe('Dating Show Notebook');
+    });
+
+    /* Verifies extraction of uppercase letters to form the prefix. */
+    it('extracts uppercase letters correctly', () => {
+      expect(getPageTitle('C:\\D\\Def\\AlphaBetaCenter')).toBe('ABC - Dating Show Notebook');
+      expect(getPageTitle('/home/user/AlphaBetaCenter')).toBe('ABC - Dating Show Notebook');
+    });
+
+    /* Ensures the title defaults gracefully if no uppercase letters are found. */
+    it('returns base title if no uppercase letters found', () => {
+      expect(getPageTitle('C:\\D\\lowercasename')).toBe('Dating Show Notebook');
     });
   });
 });

--- a/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/layout.ts
+++ b/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/layout.ts
@@ -146,17 +146,28 @@ export function getMessageStyle(type: string, gender: string): { color: string; 
 export function calculateMessageCoords(
   fromPos: { x: number; y: number; gender: string },
   toPos: { x: number; y: number; gender: string },
-  scale: number
+  scale: number,
+  type?: string
 ) {
   const isMale = fromPos.gender === 'male';
   const targetIsMale = toPos.gender === 'male';
 
-  // Offset Y: Males shift down, Females shift up to prevent overlap on same row
-  const vOffset = (isMale ? LINE_OFFSET_Y : -LINE_OFFSET_Y) * scale;
-
   // Offset X: Move away from the image boundary slightly
   const hOffsetFrom = (isMale ? LINE_OFFSET_X : -LINE_OFFSET_X) * scale;
   const hOffsetTo = (targetIsMale ? LINE_OFFSET_X : -LINE_OFFSET_X) * scale;
+
+  // Bidirectional messages should not have vertical offsets and connect to the vertical middle
+  if (type === 'bidirectional') {
+    return {
+      x1: fromPos.x + hOffsetFrom,
+      y1: fromPos.y,
+      x2: toPos.x + hOffsetTo,
+      y2: toPos.y,
+    };
+  }
+
+  // Offset Y: Males shift down, Females shift up to prevent overlap on same row
+  const vOffset = (isMale ? LINE_OFFSET_Y : -LINE_OFFSET_Y) * scale;
 
   return {
     x1: fromPos.x + hOffsetFrom,
@@ -223,4 +234,19 @@ export function wrapText(text: string, maxWidth: number, fontSize: number): stri
     lines.push(currentLine);
   }
   return lines;
+}
+
+/**
+ * Generates a page title based on the current folder path.
+ * Extracts uppercase letters from the folder name.
+ */
+export function getPageTitle(folderPath: string | null): string {
+  const BASE_TITLE = 'Dating Show Notebook';
+  if (!folderPath) {
+    return BASE_TITLE;
+  }
+  const parts = folderPath.split(/[\\/]/);
+  const lastPart = parts[parts.length - 1] || parts[parts.length - 2] || '';
+  const upperLetters = lastPart.replace(/[^A-Z]/g, '');
+  return upperLetters ? `${upperLetters} - ${BASE_TITLE}` : BASE_TITLE;
 }

--- a/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/svgRenderer.ts
+++ b/Code/2026/20260326_DatingShowNotebook/frontend/src/utils/svgRenderer.ts
@@ -251,7 +251,7 @@ export function renderEventToSvgString(event: Event, data: AppData, episodeIndex
             }
 
             const { color, marker } = getMessageStyle(m.type, fromPos.gender);
-            const { x1, y1, x2, y2 } = calculateMessageCoords(fromPos, toPos, scale);
+            const { x1, y1, x2, y2 } = calculateMessageCoords(fromPos, toPos, scale, m.type);
 
             const markerEndAttr = marker ? `marker-end="url(#${marker})"` : '';
 

--- a/Code/2026/20260510_Python/check.cmd
+++ b/Code/2026/20260510_Python/check.cmd
@@ -20,5 +20,22 @@ if %TEST_RESULT% neq 0 (
     exit /b %TEST_RESULT%
 )
 
+echo Running UI Tests...
+:: Start server in background
+start /B node src/serve.js > test_output\server.log 2>&1
+:: Wait for server to start
+timeout /t 2 > nul
+call npm run test:ui > test_output\ui.log 2>&1
+set UI_RESULT=%ERRORLEVEL%
+type test_output\ui.log
+
+:: Kill background server
+for /f "tokens=5" %%a in ('netstat -aon ^| findstr :8080') do taskkill /F /PID %%a > nul 2>&1
+
+if %UI_RESULT% neq 0 (
+    echo [ERROR] UI tests failed.
+    exit /b %UI_RESULT%
+)
+
 echo [SUCCESS] All checks passed.
 endlocal

--- a/Code/2026/20260510_Python/package.json
+++ b/Code/2026/20260510_Python/package.json
@@ -6,7 +6,7 @@
   "main": "main.js",
   "scripts": {
     "test": "vitest run --coverage",
-    "test:ui": "npx playwright test ui.test.ts",
+    "test:ui": "npx playwright test src/ui.test.ts src/infinite.test.ts src/diagnose.test.ts",
     "serve": "node src/serve.js",
     "coverage": "c8 report --reporter=text"
   },

--- a/Code/2026/20260510_Python/pub/js/compiler.js
+++ b/Code/2026/20260510_Python/pub/js/compiler.js
@@ -48,25 +48,32 @@ export class Compiler {
             case "Assignment":
                 return (this.emitExpressionWAT(node.value) + `\nlocal.set $${node.target}`);
             case "While":
+                const loopContent = this.emitExpressionWAT(node.condition) +
+                    "\ni32.eqz\nbr_if 1\n" +
+                    node.body
+                        .map((s) => this.emitStatementWAT(s))
+                        .filter((s) => s)
+                        .join("\n") +
+                    "\nbr 0";
                 return (`block\n` +
                     `  loop\n` +
-                    `    ${this.emitExpressionWAT(node.condition)}\n` +
-                    `    i32.eqz\n` +
-                    `    br_if 1\n` +
-                    `    ${node.body.map((s) => this.emitStatementWAT(s)).join("\n")}\n` +
-                    `    br 0\n` +
+                    `${this.indent(this.indent(loopContent))}\n` +
                     `  end\n` +
                     `end`);
             case "If":
-                const thenBranch = node.thenBranch
+                const thenBranch = this.indent(node.thenBranch
                     .map((s) => this.emitStatementWAT(s))
-                    .join("\n");
+                    .filter((s) => s)
+                    .join("\n"));
                 const elseBranch = node.elseBranch
-                    ? `else\n  ${node.elseBranch.map((s) => this.emitStatementWAT(s)).join("\n")}\n`
+                    ? `else\n${this.indent(node.elseBranch
+                        .map((s) => this.emitStatementWAT(s))
+                        .filter((s) => s)
+                        .join("\n"))}\n`
                     : "";
                 return (`${this.emitExpressionWAT(node.condition)}\n` +
                     `if\n` +
-                    `  ${thenBranch}\n` +
+                    `${thenBranch}\n` +
                     `${elseBranch}` +
                     `end`);
             case "CallExpression":
@@ -75,6 +82,14 @@ export class Compiler {
             default:
                 return "";
         }
+    }
+    indent(text) {
+        if (!text)
+            return "";
+        return text
+            .split("\n")
+            .map((line) => "  " + line)
+            .join("\n");
     }
     emitExpressionWAT(node) {
         switch (node.type) {

--- a/Code/2026/20260510_Python/pub/js/verify_wat.js
+++ b/Code/2026/20260510_Python/pub/js/verify_wat.js
@@ -1,0 +1,19 @@
+import { Lexer } from "./lexer.js";
+import { Parser } from "./parser.js";
+import { Compiler } from "./compiler.js";
+import * as fs from "fs";
+import * as path from "path";
+async function verify() {
+    const compiler = new Compiler();
+    const samples = ["branching.py", "infinite.py"];
+    const sampleDir = path.join(process.cwd(), "pub", "sample");
+    for (const sampleFile of samples) {
+        console.log(`\n--- WAT for ${sampleFile} ---`);
+        const code = fs.readFileSync(path.join(sampleDir, sampleFile), "utf-8");
+        const tokens = new Lexer(code).tokenize();
+        const ast = new Parser(tokens).parse();
+        const wat = compiler.compileWAT(ast);
+        console.log(wat);
+    }
+}
+verify();

--- a/Code/2026/20260510_Python/src/compiler.ts
+++ b/Code/2026/20260510_Python/src/compiler.ts
@@ -64,28 +64,40 @@ export class Compiler {
           this.emitExpressionWAT(node.value) + `\nlocal.set $${node.target}`
         );
       case "While":
+        const loopContent =
+          this.emitExpressionWAT(node.condition) +
+          "\ni32.eqz\nbr_if 1\n" +
+          node.body
+            .map((s) => this.emitStatementWAT(s))
+            .filter((s) => s)
+            .join("\n") +
+          "\nbr 0";
         return (
           `block\n` +
           `  loop\n` +
-          `    ${this.emitExpressionWAT(node.condition)}\n` +
-          `    i32.eqz\n` +
-          `    br_if 1\n` +
-          `    ${node.body.map((s) => this.emitStatementWAT(s)).join("\n")}\n` +
-          `    br 0\n` +
+          `${this.indent(this.indent(loopContent))}\n` +
           `  end\n` +
           `end`
         );
       case "If":
-        const thenBranch = node.thenBranch
-          .map((s) => this.emitStatementWAT(s))
-          .join("\n");
+        const thenBranch = this.indent(
+          node.thenBranch
+            .map((s) => this.emitStatementWAT(s))
+            .filter((s) => s)
+            .join("\n"),
+        );
         const elseBranch = node.elseBranch
-          ? `else\n  ${node.elseBranch.map((s) => this.emitStatementWAT(s)).join("\n")}\n`
+          ? `else\n${this.indent(
+              node.elseBranch
+                .map((s) => this.emitStatementWAT(s))
+                .filter((s) => s)
+                .join("\n"),
+            )}\n`
           : "";
         return (
           `${this.emitExpressionWAT(node.condition)}\n` +
           `if\n` +
-          `  ${thenBranch}\n` +
+          `${thenBranch}\n` +
           `${elseBranch}` +
           `end`
         );
@@ -97,6 +109,14 @@ export class Compiler {
       default:
         return "";
     }
+  }
+
+  private indent(text: string): string {
+    if (!text) return "";
+    return text
+      .split("\n")
+      .map((line) => "  " + line)
+      .join("\n");
   }
 
   private emitExpressionWAT(node: ASTNode): string {

--- a/Code/2026/20260510_Python/src/compiler.vitest.test.ts
+++ b/Code/2026/20260510_Python/src/compiler.vitest.test.ts
@@ -1,10 +1,9 @@
-import { Lexer } from "./lexer.js";
-import { Parser } from "./parser.js";
-import { Compiler } from "./compiler.js";
+import { describe, it, expect } from "vitest";
+import { Lexer } from "./lexer.ts";
+import { Parser } from "./parser.ts";
+import { Compiler } from "./compiler.ts";
 
-async function test() {
-  console.log("Running Compiler Tests...");
-
+describe("Compiler Integration", () => {
   const cases = [
     {
       name: "Basic Return",
@@ -28,9 +27,8 @@ async function test() {
     },
   ];
 
-  let passed = 0;
   for (const c of cases) {
-    try {
+    it(`should pass case: ${c.name}`, async () => {
       const lexer = new Lexer(c.code);
       const tokens = lexer.tokenize();
       const parser = new Parser(tokens);
@@ -40,24 +38,21 @@ async function test() {
       compiler.compileWAT(ast);
       const wasm = compiler.compileWASM(ast);
 
+      const importObject = {
+        env: {
+          print: () => {},
+          sleep: () => {},
+        },
+      };
+
       // Verify by running in WASM runtime
-      const { instance } = (await WebAssembly.instantiate(wasm)) as any;
+      const { instance } = (await WebAssembly.instantiate(
+        wasm,
+        importObject,
+      )) as any;
       const result = (instance.exports.main as Function)();
 
-      if (result === c.expectedResult) {
-        console.log(`✅ [PASS] ${c.name} (Result: ${result})`);
-        passed++;
-      } else {
-        console.log(`❌ [FAIL] ${c.name}`);
-        console.log(`   Expected: ${c.expectedResult}, Actual: ${result}`);
-      }
-    } catch (e) {
-      console.log(`❌ [ERROR] ${c.name}: ${e}`);
-    }
+      expect(result).toBe(c.expectedResult);
+    });
   }
-
-  console.log(`\nTests: ${passed}/${cases.length} passed`);
-  if (passed !== cases.length) process.exit(1);
-}
-
-test();
+});

--- a/Code/2026/20260510_Python/src/indentation.vitest.test.ts
+++ b/Code/2026/20260510_Python/src/indentation.vitest.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { Lexer } from "./lexer.ts";
+import { Parser } from "./parser.ts";
+import { Compiler } from "./compiler.ts";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Compiler WAT Indentation", () => {
+  const compiler = new Compiler();
+
+  const testIndentation = (
+    name: string,
+    pythonCode: string,
+    expectedInWat: string[],
+  ) => {
+    const tokens = new Lexer(pythonCode).tokenize();
+    const ast = new Parser(tokens).parse();
+    const wat = compiler.compileWAT(ast);
+
+    // Save verbose output to test_output folder
+    const outputDir = path.join(process.cwd(), "test_output");
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir);
+    }
+    const safeName = name.replace(/[^a-z0-9]/gi, "_").toLowerCase();
+    fs.writeFileSync(path.join(outputDir, `indent_${safeName}.wat`), wat);
+
+    for (const expected of expectedInWat) {
+      expect(wat).toContain(expected);
+    }
+  };
+
+  it("should correctly indent if-else blocks", () => {
+    const code = `
+def main():
+    x = 42
+    if x > 0:
+        return 1
+    else:
+        return 0
+`;
+    testIndentation("if_else", code, [
+      "    if\n      i32.const 1\n      return\n    else\n      i32.const 0\n      return\n    end",
+    ]);
+  });
+
+  it("should correctly indent while loop blocks", () => {
+    const code = `
+def main():
+    while True:
+        print(1)
+`;
+    testIndentation("while_loop", code, [
+      "    block\n      loop\n        i32.const 1\n        i32.eqz\n        br_if 1\n        i32.const 1\n        call $print\n        br 0\n      end",
+    ]);
+  });
+
+  it("should correctly indent nested blocks", () => {
+    const code = `
+def main():
+    if True:
+        while True:
+            return 1
+`;
+    // Nested blocks should have cumulative indentation
+    testIndentation("nested_blocks", code, [
+      "    if\n      block\n        loop\n          i32.const 1\n          i32.eqz\n          br_if 1\n          i32.const 1\n          return\n          br 0\n        end\n      end\n    end",
+    ]);
+  });
+});

--- a/Code/2026/20260510_Python/src/infinite.test.ts
+++ b/Code/2026/20260510_Python/src/infinite.test.ts
@@ -8,8 +8,9 @@ test("verify infinite loop and abort", async ({ page }) => {
   // Select infinite loop sample
   await page.selectOption("#sample-select", "sample/infinite.py");
 
-  // Verify editor content
-  await expect(page.locator("#editor")).toContainText("while True:");
+  // Verify editor content - wait for it to load
+  const editor = page.locator("#editor");
+  await expect(editor).toHaveValue(/while True:/, { timeout: 10000 });
 
   // Trigger compile & run
   await page.click("#compile-btn");

--- a/Code/2026/20260510_Python/src/lexer.vitest.test.ts
+++ b/Code/2026/20260510_Python/src/lexer.vitest.test.ts
@@ -1,8 +1,7 @@
-import { Lexer, TokenType } from "./lexer.js";
+import { describe, it, expect } from "vitest";
+import { Lexer, TokenType } from "./lexer.ts";
 
-function test() {
-  console.log("Running Lexer Tests...");
-
+describe("Lexer Legacy Tests", () => {
   const cases = [
     {
       name: "Basic Function",
@@ -102,40 +101,17 @@ function test() {
     },
   ];
 
-  let passed = 0;
-  cases.forEach((c) => {
-    try {
+  for (const c of cases) {
+    it(`should pass case: ${c.name}`, () => {
       const lexer = new Lexer(c.code);
       const tokens = lexer.tokenize();
       const types = tokens.map((t) => t.type);
-
-      const isMatch = JSON.stringify(types) === JSON.stringify(c.expected);
-      if (isMatch) {
-        console.log(`✅ [PASS] ${c.name}`);
-        passed++;
-      } else {
-        console.log(`❌ [FAIL] ${c.name}`);
-        console.log("   Expected:", c.expected.join(", "));
-        console.log("   Actual:  ", types.join(", "));
-      }
-    } catch (e) {
-      console.log(`❌ [ERROR] ${c.name}: ${e}`);
-    }
-  });
-
-  // Test error case
-  try {
-    console.log("Testing unexpected character error...");
-    const lexer = new Lexer("@");
-    lexer.tokenize();
-    console.log("❌ [FAIL] Expected error for @");
-  } catch {
-    console.log("✅ [PASS] Unexpected character error caught");
-    passed++;
+      expect(types).toEqual(c.expected);
+    });
   }
-  const total = cases.length + 1;
-  console.log(`\nTests: ${passed}/${total} passed`);
-  if (passed !== total) process.exit(1);
-}
 
-test();
+  it("should throw on unexpected character error", () => {
+    const lexer = new Lexer("@");
+    expect(() => lexer.tokenize()).toThrow();
+  });
+});

--- a/Code/2026/20260510_Python/src/parser.vitest.test.ts
+++ b/Code/2026/20260510_Python/src/parser.vitest.test.ts
@@ -1,9 +1,8 @@
-import { Lexer } from "./lexer.js";
-import { Parser } from "./parser.js";
+import { describe, it, expect } from "vitest";
+import { Lexer } from "./lexer.ts";
+import { Parser } from "./parser.ts";
 
-function test() {
-  console.log("Running Parser Tests...");
-
+describe("Parser Legacy Tests", () => {
   const cases = [
     {
       name: "Basic Function AST",
@@ -48,49 +47,28 @@ function test() {
     },
   ];
 
-  let passed = 0;
-  cases.forEach((c) => {
-    try {
+  for (const c of cases) {
+    it(`should pass case: ${c.name}`, () => {
       const lexer = new Lexer(c.code);
       const tokens = lexer.tokenize();
       const parser = new Parser(tokens);
       const ast = parser.parse();
+      expect(c.validate(ast)).toBe(true);
+    });
+  }
 
-      if (c.validate(ast)) {
-        console.log(`✅ [PASS] ${c.name}`);
-        passed++;
-      } else {
-        console.log(`❌ [FAIL] ${c.name}`);
-        console.log("   AST:", JSON.stringify(ast, null, 2));
-      }
-    } catch (e) {
-      console.log(`❌ [ERROR] ${c.name}: ${e}`);
-    }
-  });
-
-  // Test error cases
   const errorCases = [
     { name: "Unexpected token", code: "def main():\n    return 1 2" },
     { name: "Expect function name", code: "def ():" },
     { name: "Expect expression", code: "def main():\n    return +" },
   ];
 
-  errorCases.forEach((ec) => {
-    try {
+  for (const ec of errorCases) {
+    it(`should throw on ${ec.name}`, () => {
       const lexer = new Lexer(ec.code);
       const tokens = lexer.tokenize();
       const parser = new Parser(tokens);
-      parser.parse();
-      console.log(`❌ [FAIL] ${ec.name}: Expected error`);
-    } catch (e) {
-      console.log(`✅ [PASS] ${ec.name} error caught: ${e}`);
-      passed++;
-    }
-  });
-
-  const total = cases.length + errorCases.length;
-  console.log(`\nTests: ${passed}/${total} passed`);
-  if (passed !== total) process.exit(1);
-}
-
-test();
+      expect(() => parser.parse()).toThrow();
+    });
+  }
+});

--- a/Code/2026/20260510_Python/src/vitest.setup.ts
+++ b/Code/2026/20260510_Python/src/vitest.setup.ts
@@ -1,0 +1,36 @@
+import { vi, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const logFile = path.join(process.cwd(), "test_output", "console.log");
+
+// Ensure directory exists
+if (!fs.existsSync(path.dirname(logFile))) {
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+}
+
+// Clear log file at start
+fs.writeFileSync(logFile, "");
+
+beforeAll(() => {
+  const logToDir = (type: string, ...args: any[]) => {
+    const message = args
+      .map((arg) => (typeof arg === "object" ? JSON.stringify(arg) : arg))
+      .join(" ");
+    fs.appendFileSync(logFile, `[${type}] ${message}\n`);
+  };
+
+  vi.spyOn(console, "log").mockImplementation((...args) =>
+    logToDir("LOG", ...args),
+  );
+  vi.spyOn(console, "error").mockImplementation((...args) =>
+    logToDir("ERROR", ...args),
+  );
+  vi.spyOn(console, "warn").mockImplementation((...args) =>
+    logToDir("WARN", ...args),
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});

--- a/Code/2026/20260510_Python/test-results/.last-run.json
+++ b/Code/2026/20260510_Python/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/Code/2026/20260510_Python/vitest.config.ts
+++ b/Code/2026/20260510_Python/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     include: ["src/**/*.vitest.test.ts", "src/unit-tests.test.ts"],
+    setupFiles: ["src/vitest.setup.ts"],
     coverage: {
       provider: "v8",
       include: [


### PR DESCRIPTION
- Refine Python-WASM WAT formatting and migrate compiler tests to Vitest
- Add UI test execution, logging setup, and more reliable infinite-loop checks
- Update Dating Show Notebook page titles from folder names during SSR/client
- Fix bidirectional message line positioning and add layout coverage tests