### PR TITLE
RC-Const: Immutable Reference-Counting Coding Style for Rust

### DIFF
--- a/Code/2026/20260617_RcConst/.gitignore
+++ b/Code/2026/20260617_RcConst/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Code/2026/20260617_RcConst/Cargo.toml
+++ b/Code/2026/20260617_RcConst/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "rc-const-demo",
     "rc-const-test",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"

--- a/Code/2026/20260617_RcConst/Cargo.toml
+++ b/Code/2026/20260617_RcConst/Cargo.toml
@@ -1,0 +1,10 @@
+﻿[workspace]
+members = [
+    "rc-const",
+    "rc-const-demo",
+    "rc-const-test",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"

--- a/Code/2026/20260617_RcConst/README.md
+++ b/Code/2026/20260617_RcConst/README.md
@@ -43,10 +43,10 @@ C:\D\Code\Code\2026\20260617_RcConst\
 ```
 
 ### Environment Setup
-- **Rust/Cargo**: Installed in C:\Users\jianh\.cargo\bin.
-- **MinGW**: C:\D\mingw\bin\gcc.exe (Used for linking if needed).
+- **Rust/Cargo**: Installed in `C:\Users\my-user-name\.cargo\bin`.
+- **MinGW (Optional)**: If using the GNU toolchain, `C:\D\mingw\bin\gcc.exe` may be required.
 - **Environment Variables**:
-    - **PATH**: Should include C:\Users\jianh\.cargo\bin and C:\D\mingw\bin.
+    - **PATH**: Should include `C:\Users\my-user-name\.cargo\bin`.
 
 ---
 

--- a/Code/2026/20260617_RcConst/README.md
+++ b/Code/2026/20260617_RcConst/README.md
@@ -1,0 +1,68 @@
+﻿# RC-Const: Reference-Counting Constant Objects in Rust
+
+## Introduction
+RC-Const is a specialized coding style and supporting classes for Rust that prioritizes immutability and simplified memory management, similar to Garbage-Collected (GC) languages like C#, JavaScript, or Go, while maintaining Rust's performance and safety.
+
+### Core Principles
+1. **Immutability by Default**: Objects cannot be modified after construction. Any 'change' results in the creation of a new object.
+2. **Restricted Types**: Only primitive types (e.g., i32, bool, f64) and reference-counted immutable objects (Rc<T>) are allowed in the public API of RC-Const objects.
+3. **Cycle-Free Design**: Since objects are immutable, an object can only reference previously created objects. This naturally prevents reference cycles, eliminating the need for a Garbage Collector.
+4. **No Explicit Borrows**: By avoiding '&' references in general logic and relying on Rc and Copy types, we bypass many of the complexities of the Rust borrow checker for application-level logic.
+
+### Pros and Cons
+- **Pros**:
+    - Simplified lifecycle management (GC-like experience).
+    - No reference cycles (no memory leaks from cycles).
+    - Functional style (easier to reason about state).
+- **Cons**:
+    - Performance overhead for frequent 'mutations' (allocations).
+    - Memory usage due to many small allocations.
+    - Deviation from standard Rust idioms (e.g., list = list.append(3)).
+
+---
+
+## Project Structure
+The project is organized as a Cargo workspace:
+
+C:\D\Code\Code\2026\20260617_RcConst\
+├── .gitignore
+├── Cargo.toml (Workspace)
+├── README.md (This plan)
+├── build.cmd (Shortcut to compile)
+├── test.cmd (Shortcut to run tests)
+├── run.cmd (Shortcut to run demo)
+├── rc-const/ (Support Library)
+│   ├── src/
+│   │   ├── lib.rs (Core traits and macros)
+│   │   └── builders.rs (ListBuilder, MapBuilder)
+├── rc-const-demo/ (Demo Project)
+│   └── src/main.rs
+└── rc-const-test/ (Unit and Integration Tests)
+    └── src/lib.rs
+
+### Environment Setup
+- **Rust/Cargo**: Installed in C:\Users\jianh\.cargo\bin.
+- **MinGW**: C:\D\mingw\bin\gcc.exe (Used for linking if needed).
+- **Environment Variables**:
+    - **PATH**: Should include C:\Users\jianh\.cargo\bin and C:\D\mingw\bin.
+
+---
+
+## Supporting Library (rc-const)
+The library provides the backbone for this coding style:
+- **Builders Pattern**: To mitigate the cost of appending to collections.
+    - **ListBuilder<T>**: Uses a linked-list of nodes internally for O(1) append, then converts to a contiguous array on build().
+- **Macros**: To simplify the creation of 'wither' methods (e.g., set_x).
+
+---
+
+## Implementation Plan
+1. **Phase 1: Scaffolding**: Create the folder structure and workspace configuration.
+2. **Phase 2: Support Library**: Implement ListBuilder and basic RcConst traits.
+3. **Phase 3: Demo Implementation**: Create a small application (e.g., a simple tree-based calculator or document model) using the RC-Const style.
+4. **Phase 4: Validation**: Write tests in rc-const-test to ensure no cycles are created and the Builder pattern works efficiently.
+
+## Development Shortcuts
+- build.cmd: cargo build --workspace
+- test.cmd: cargo test --workspace
+- run.cmd: cargo run --package rc-const-demo

--- a/Code/2026/20260617_RcConst/README.md
+++ b/Code/2026/20260617_RcConst/README.md
@@ -1,4 +1,4 @@
-﻿# RC-Const: Reference-Counting Constant Objects in Rust
+# RC-Const: Reference-Counting Constant Objects in Rust
 
 ## Introduction
 RC-Const is a specialized coding style and supporting classes for Rust that prioritizes immutability and simplified memory management, similar to Garbage-Collected (GC) languages like C#, JavaScript, or Go, while maintaining Rust's performance and safety.
@@ -24,6 +24,7 @@ RC-Const is a specialized coding style and supporting classes for Rust that prio
 ## Project Structure
 The project is organized as a Cargo workspace:
 
+```text
 C:\D\Code\Code\2026\20260617_RcConst\
 ├── .gitignore
 ├── Cargo.toml (Workspace)
@@ -34,11 +35,12 @@ C:\D\Code\Code\2026\20260617_RcConst\
 ├── rc-const/ (Support Library)
 │   ├── src/
 │   │   ├── lib.rs (Core traits and macros)
-│   │   └── builders.rs (ListBuilder, MapBuilder)
+│   │   └── builders.rs (ListBuilder, MapBuilder, SetBuilder)
 ├── rc-const-demo/ (Demo Project)
 │   └── src/main.rs
 └── rc-const-test/ (Unit and Integration Tests)
     └── src/lib.rs
+```
 
 ### Environment Setup
 - **Rust/Cargo**: Installed in C:\Users\jianh\.cargo\bin.
@@ -52,6 +54,8 @@ C:\D\Code\Code\2026\20260617_RcConst\
 The library provides the backbone for this coding style:
 - **Builders Pattern**: To mitigate the cost of appending to collections.
     - **ListBuilder<T>**: Uses a linked-list of nodes internally for O(1) append, then converts to a contiguous array on build().
+    - **MapBuilder<K, V>**: Fluent builder for `ConstMap`.
+    - **SetBuilder<T>**: Fluent builder for `ConstSet`.
 - **Macros**: To simplify the creation of 'wither' methods (e.g., set_x).
 
 ---

--- a/Code/2026/20260617_RcConst/build.cmd
+++ b/Code/2026/20260617_RcConst/build.cmd
@@ -1,0 +1,3 @@
+@echo off
+cd /d %~dp0
+cargo build --workspace

--- a/Code/2026/20260617_RcConst/rc-const-demo/Cargo.toml
+++ b/Code/2026/20260617_RcConst/rc-const-demo/Cargo.toml
@@ -1,0 +1,7 @@
+﻿[package]
+name = "rc-const-demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rc-const = { path = "../rc-const" }

--- a/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
+++ b/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
@@ -1,17 +1,17 @@
 use std::rc::Rc;
-use rc_const::{ListBuilder, ConstStr, ConstVec, ConstMap};
+use rc_const::{ListBuilder, ConstString, ConstVec, ConstMap};
 
 #[derive(Debug, Clone)]
 struct Person {
-    name: ConstStr,
+    name: Rc<ConstString>,
     age: i32,
-    friends: ConstVec<Rc<Person>>,
+    friends: Rc<ConstVec<Rc<Person>>>,
 }
 
 impl Person {
-    fn new(name: &str, age: i32) -> Rc<Self> {
+    fn new(name: Rc<ConstString>, age: i32) -> Rc<Self> {
         Rc::new(Person {
-            name: ConstStr::new(name),
+            name,
             age,
             friends: ConstVec::new(),
         })
@@ -19,42 +19,47 @@ impl Person {
 
     fn set_age(self: &Rc<Self>, age: i32) -> Rc<Self> {
         Rc::new(Person {
-            name: self.name.clone(),
             age,
-            friends: self.friends.clone(),
+            ..(**self).clone()
         })
     }
 
     fn add_friend(self: &Rc<Self>, friend: Rc<Person>) -> Rc<Self> {
         Rc::new(Person {
-            name: self.name.clone(),
-            age: self.age,
             friends: self.friends.push(friend),
+            ..(**self).clone()
         })
     }
 }
 
 fn main() {
-    let mut alice = Person::new("Alice", 30);
-    let bob = Person::new("Bob", 25);
+    let name_alice = ConstString::new("Alice");
+    let name_bob = ConstString::new("Bob");
+
+    let mut alice = Person::new(name_alice, 30);
+    let mut bob = Person::new(name_bob, 25);
 
     alice = alice.set_age(31);
-    alice = alice.add_friend(bob.clone());
+    alice = alice.add_friend(bob.clone()); 
 
-    println!("Alice: {:?}", alice);
+    // Use {:#?} for pretty-printing with indentation and EOL
+    println!("Alice after adding Bob:\n{:#?}", alice);
 
-    // Using ListBuilder to create ConstVec
-    let mut builder = ListBuilder::<i32>::new();
-    for i in 0..10 {
-        builder = builder.append(i);
-    }
-    let list = builder.build();
-    println!("List from builder (ConstVec): {:?}", list);
+    bob = bob.add_friend(alice.clone());
 
-    // Using ConstMap
-    let mut map = ConstMap::<ConstStr, Rc<Person>>::new();
+    println!("\nBob after adding Alice:\n{:#?}", bob);
+    
+    // Using ConstMap with Rc handles
+    let mut map = ConstMap::<Rc<ConstString>, Rc<Person>>::new();
     map = map.insert(alice.name.clone(), alice.clone());
     map = map.insert(bob.name.clone(), bob.clone());
 
-    println!("Map contains Alice: {:?}", map.get(&alice.name));
+    println!("\nMap contains Alice:\n{:#?}", map.get(&alice.name));
+    
+    // ListBuilder demonstration
+    let mut lb = ListBuilder::<i32>::new();
+    for i in 1..=3 {
+        lb = lb.append(i);
+    }
+    println!("\nFinal list: {:#?}", lb.build());
 }

--- a/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
+++ b/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
@@ -1,4 +1,4 @@
-﻿use std::rc::Rc;
+use std::rc::Rc;
 use rc_const::{ListBuilder, ConstStr, ConstVec, ConstMap};
 
 #[derive(Debug, Clone)]

--- a/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
+++ b/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
@@ -1,0 +1,54 @@
+﻿use std::rc::Rc;
+use rc_const::ListBuilder;
+
+#[derive(Debug, Clone)]
+struct Person {
+    name: String,
+    age: i32,
+    friends: Rc<Vec<Rc<Person>>>,
+}
+
+impl Person {
+    fn new(name: &str, age: i32) -> Rc<Self> {
+        Rc::new(Person {
+            name: name.to_string(),
+            age,
+            friends: Rc::new(Vec::new()),
+        })
+    }
+
+    fn set_age(self: &Rc<Self>, age: i32) -> Rc<Self> {
+        Rc::new(Person {
+            name: self.name.clone(),
+            age,
+            friends: self.friends.clone(),
+        })
+    }
+
+    fn add_friend(self: &Rc<Self>, friend: Rc<Person>) -> Rc<Self> {
+        let mut new_friends = (*self.friends).clone();
+        new_friends.push(friend);
+        Rc::new(Person {
+            name: self.name.clone(),
+            age: self.age,
+            friends: Rc::new(new_friends),
+        })
+    }
+}
+
+fn main() {
+    let mut alice = Person::new("Alice", 30);
+    let bob = Person::new("Bob", 25);
+
+    alice = alice.set_age(31);
+    alice = alice.add_friend(bob.clone());
+
+    println!("Alice: {:?}", alice);
+
+    let mut builder = ListBuilder::<i32>::new();
+    for i in 0..10 {
+        builder = builder.append(i);
+    }
+    let list = builder.build();
+    println!("List from builder: {:?}", list);
+}

--- a/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
+++ b/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
@@ -17,6 +17,16 @@ impl Person {
         })
     }
 
+    /// Getter for name
+    fn get_name(&self) -> Rc<ConstString> {
+        self.name.clone()
+    }
+
+    /// Getter for age
+    fn get_age(&self) -> i32 {
+        self.age
+    }
+
     fn set_age(self: &Rc<Self>, age: i32) -> Rc<Self> {
         Rc::new(Person {
             age,
@@ -42,12 +52,14 @@ fn main() {
     alice = alice.set_age(31);
     alice = alice.add_friend(bob.clone()); 
 
-    // Use {:#?} for pretty-printing with indentation and EOL
+    // Explicitly use the fields to avoid dead_code warnings
+    println!("Alice's new age: {}", alice.get_age());
     println!("Alice after adding Bob:\n{:#?}", alice);
 
     bob = bob.add_friend(alice.clone());
 
-    println!("\nBob after adding Alice:\n{:#?}", bob);
+    println!("\nBob's friend is: {}", bob.friends.get(0).unwrap().get_name());
+    println!("Bob after adding Alice:\n{:#?}", bob);
     
     // Using ConstMap with Rc handles
     let mut map = ConstMap::<Rc<ConstString>, Rc<Person>>::new();

--- a/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
+++ b/Code/2026/20260617_RcConst/rc-const-demo/src/main.rs
@@ -1,19 +1,19 @@
 ﻿use std::rc::Rc;
-use rc_const::ListBuilder;
+use rc_const::{ListBuilder, ConstStr, ConstVec, ConstMap};
 
 #[derive(Debug, Clone)]
 struct Person {
-    name: String,
+    name: ConstStr,
     age: i32,
-    friends: Rc<Vec<Rc<Person>>>,
+    friends: ConstVec<Rc<Person>>,
 }
 
 impl Person {
     fn new(name: &str, age: i32) -> Rc<Self> {
         Rc::new(Person {
-            name: name.to_string(),
+            name: ConstStr::new(name),
             age,
-            friends: Rc::new(Vec::new()),
+            friends: ConstVec::new(),
         })
     }
 
@@ -26,12 +26,10 @@ impl Person {
     }
 
     fn add_friend(self: &Rc<Self>, friend: Rc<Person>) -> Rc<Self> {
-        let mut new_friends = (*self.friends).clone();
-        new_friends.push(friend);
         Rc::new(Person {
             name: self.name.clone(),
             age: self.age,
-            friends: Rc::new(new_friends),
+            friends: self.friends.push(friend),
         })
     }
 }
@@ -45,10 +43,18 @@ fn main() {
 
     println!("Alice: {:?}", alice);
 
+    // Using ListBuilder to create ConstVec
     let mut builder = ListBuilder::<i32>::new();
     for i in 0..10 {
         builder = builder.append(i);
     }
     let list = builder.build();
-    println!("List from builder: {:?}", list);
+    println!("List from builder (ConstVec): {:?}", list);
+
+    // Using ConstMap
+    let mut map = ConstMap::<ConstStr, Rc<Person>>::new();
+    map = map.insert(alice.name.clone(), alice.clone());
+    map = map.insert(bob.name.clone(), bob.clone());
+
+    println!("Map contains Alice: {:?}", map.get(&alice.name));
 }

--- a/Code/2026/20260617_RcConst/rc-const-test/Cargo.toml
+++ b/Code/2026/20260617_RcConst/rc-const-test/Cargo.toml
@@ -1,0 +1,7 @@
+﻿[package]
+name = "rc-const-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rc-const = { path = "../rc-const" }

--- a/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
@@ -1,0 +1,13 @@
+﻿#[cfg(test)]
+mod tests {
+    use rc_const::ListBuilder;
+
+    #[test]
+    fn test_list_builder() {
+        let mut b = ListBuilder::new();
+        b = b.append(1);
+        b = b.append(2);
+        let list = b.build();
+        assert_eq!(list, vec![1, 2]);
+    }
+}

--- a/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
@@ -1,11 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use rc_const::{ListBuilder, ConstStr, ConstMap};
+    use rc_const::{ListBuilder, ConstString, ConstMap};
 
     #[test]
-    fn test_const_str() {
-        let s = ConstStr::new("hello");
+    fn test_const_string() {
+        let s = ConstString::new("hello");
         assert_eq!(format!("{}", s), "hello");
+        // Test improved debug output
+        assert_eq!(format!("{:?}", s), "\"hello\"");
     }
 
     #[test]
@@ -17,12 +19,14 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert_eq!(list.get(0), Some(&1));
         assert_eq!(list.get(1), Some(&2));
+        // Test improved debug output (no ConstVec prefix)
+        assert_eq!(format!("{:?}", list), "[1, 2]");
     }
 
     #[test]
     fn test_const_map() {
         let mut m = ConstMap::new();
-        let k = ConstStr::new("key");
+        let k = ConstString::new("key");
         m = m.insert(k.clone(), 42);
         assert_eq!(m.get(&k), Some(&42));
     }

--- a/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
@@ -1,13 +1,30 @@
 ﻿#[cfg(test)]
 mod tests {
-    use rc_const::ListBuilder;
+    use rc_const::{ListBuilder, ConstStr, ConstVec, ConstMap};
+    use std::rc::Rc;
 
     #[test]
-    fn test_list_builder() {
+    fn test_const_str() {
+        let s = ConstStr::new("hello");
+        assert_eq!(format!("{}", s), "hello");
+    }
+
+    #[test]
+    fn test_list_builder_const_vec() {
         let mut b = ListBuilder::new();
         b = b.append(1);
         b = b.append(2);
         let list = b.build();
-        assert_eq!(list, vec![1, 2]);
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get(0), Some(&1));
+        assert_eq!(list.get(1), Some(&2));
+    }
+
+    #[test]
+    fn test_const_map() {
+        let mut m = ConstMap::new();
+        let k = ConstStr::new("key");
+        m = m.insert(k.clone(), 42);
+        assert_eq!(m.get(&k), Some(&42));
     }
 }

--- a/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const-test/src/lib.rs
@@ -1,7 +1,6 @@
-﻿#[cfg(test)]
+#[cfg(test)]
 mod tests {
-    use rc_const::{ListBuilder, ConstStr, ConstVec, ConstMap};
-    use std::rc::Rc;
+    use rc_const::{ListBuilder, ConstStr, ConstMap};
 
     #[test]
     fn test_const_str() {

--- a/Code/2026/20260617_RcConst/rc-const/Cargo.toml
+++ b/Code/2026/20260617_RcConst/rc-const/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rc-const"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]

--- a/Code/2026/20260617_RcConst/rc-const/src/builders.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/builders.rs
@@ -1,4 +1,4 @@
-﻿use std::rc::Rc;
+use std::rc::Rc;
 use crate::ConstVec;
 
 pub struct ListBuilder<T> {

--- a/Code/2026/20260617_RcConst/rc-const/src/builders.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/builders.rs
@@ -1,0 +1,38 @@
+﻿use std::rc::Rc;
+
+pub struct ListBuilder<T> {
+    item: Option<T>,
+    prev: Option<Rc<ListBuilder<T>>>,
+    size: usize,
+}
+
+impl<T: Clone> ListBuilder<T> {
+    pub fn new() -> Rc<Self> {
+        Rc::new(ListBuilder {
+            item: None,
+            prev: None,
+            size: 0,
+        })
+    }
+
+    pub fn append(self: &Rc<Self>, item: T) -> Rc<Self> {
+        Rc::new(ListBuilder {
+            item: Some(item),
+            prev: Some(self.clone()),
+            size: self.size + 1,
+        })
+    }
+
+    pub fn build(&self) -> Vec<T> {
+        let mut items = Vec::with_capacity(self.size);
+        let mut curr = Some(self);
+        while let Some(node) = curr {
+            if let Some(ref item) = node.item {
+                items.push(item.clone());
+            }
+            curr = node.prev.as_ref().map(|p| p.as_ref());
+        }
+        items.reverse();
+        items
+    }
+}

--- a/Code/2026/20260617_RcConst/rc-const/src/builders.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/builders.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::ConstVec;
+use std::collections::{HashMap, HashSet};
+use crate::{ConstVec, ConstMap, ConstSet};
 
 pub struct ListBuilder<T> {
     item: Option<T>,
@@ -24,7 +25,7 @@ impl<T: Clone> ListBuilder<T> {
         })
     }
 
-    pub fn build(&self) -> ConstVec<T> {
+    pub fn build(&self) -> Rc<ConstVec<T>> {
         let mut items = Vec::with_capacity(self.size);
         let mut curr = Some(self);
         while let Some(node) = curr {
@@ -35,5 +36,77 @@ impl<T: Clone> ListBuilder<T> {
         }
         items.reverse();
         ConstVec::from_vec(items)
+    }
+}
+
+pub struct MapBuilder<K, V> {
+    entry: Option<(K, V)>,
+    prev: Option<Rc<MapBuilder<K, V>>>,
+    size: usize,
+}
+
+impl<K: Clone + Eq + std::hash::Hash, V: Clone> MapBuilder<K, V> {
+    pub fn new() -> Rc<Self> {
+        Rc::new(MapBuilder {
+            entry: None,
+            prev: None,
+            size: 0,
+        })
+    }
+
+    pub fn insert(self: &Rc<Self>, key: K, value: V) -> Rc<Self> {
+        Rc::new(MapBuilder {
+            entry: Some((key, value)),
+            prev: Some(self.clone()),
+            size: self.size + 1,
+        })
+    }
+
+    pub fn build(&self) -> Rc<ConstMap<K, V>> {
+        let mut map = HashMap::with_capacity(self.size);
+        let mut curr = Some(self);
+        while let Some(node) = curr {
+            if let Some((ref k, ref v)) = node.entry {
+                map.insert(k.clone(), v.clone());
+            }
+            curr = node.prev.as_ref().map(|p| p.as_ref());
+        }
+        ConstMap::from_map(map)
+    }
+}
+
+pub struct SetBuilder<T> {
+    item: Option<T>,
+    prev: Option<Rc<SetBuilder<T>>>,
+    size: usize,
+}
+
+impl<T: Clone + Eq + std::hash::Hash> SetBuilder<T> {
+    pub fn new() -> Rc<Self> {
+        Rc::new(SetBuilder {
+            item: None,
+            prev: None,
+            size: 0,
+        })
+    }
+
+    pub fn insert(self: &Rc<Self>, item: T) -> Rc<Self> {
+        Rc::new(SetBuilder {
+            item: Some(item),
+            prev: Some(self.clone()),
+            size: self.size + 1,
+        })
+    }
+
+    pub fn build(&self) -> Rc<ConstSet<T>> {
+        let mut set = HashSet::with_capacity(self.size);
+        let mut curr = Some(self);
+        while let Some(node) = curr {
+            if let Some(ref item) = node.item {
+                set.insert(item.clone());
+            }
+            curr = node.prev.as_ref().map(|p| p.as_ref());
+        }
+        ConstSet::from_set(set)
     }
 }

--- a/Code/2026/20260617_RcConst/rc-const/src/builders.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/builders.rs
@@ -1,4 +1,5 @@
 ﻿use std::rc::Rc;
+use crate::ConstVec;
 
 pub struct ListBuilder<T> {
     item: Option<T>,
@@ -23,7 +24,7 @@ impl<T: Clone> ListBuilder<T> {
         })
     }
 
-    pub fn build(&self) -> Vec<T> {
+    pub fn build(&self) -> ConstVec<T> {
         let mut items = Vec::with_capacity(self.size);
         let mut curr = Some(self);
         while let Some(node) = curr {
@@ -33,6 +34,6 @@ impl<T: Clone> ListBuilder<T> {
             curr = node.prev.as_ref().map(|p| p.as_ref());
         }
         items.reverse();
-        items
+        ConstVec::from_vec(items)
     }
 }

--- a/Code/2026/20260617_RcConst/rc-const/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/lib.rs
@@ -1,4 +1,4 @@
-﻿use std::rc::Rc;
+use std::rc::Rc;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
@@ -12,7 +12,7 @@ impl ConstStr {
 }
 
 impl std::fmt::Display for ConstStr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<"_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/Code/2026/20260617_RcConst/rc-const/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/lib.rs
@@ -1,38 +1,48 @@
 use std::rc::Rc;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
+use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ConstStr(Rc<str>);
+/// A Constant String (meant to be used as Rc<ConstString>)
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ConstString(String);
 
-impl ConstStr {
-    pub fn new(s: &str) -> Self {
-        ConstStr(Rc::from(s))
+impl ConstString {
+    pub fn new(s: &str) -> Rc<Self> {
+        Rc::new(ConstString(s.to_string()))
     }
 }
 
-impl std::fmt::Display for ConstStr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ConstString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ConstVec<T>(Rc<Vec<T>>);
+impl fmt::Debug for ConstString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just show the string value, e.g., "Alice" instead of ConstString("Alice")
+        write!(f, "{:?}", self.0)
+    }
+}
+
+/// A Constant Vector (meant to be used as Rc<ConstVec<T>>)
+#[derive(Clone)]
+pub struct ConstVec<T>(Vec<T>);
 
 impl<T: Clone> ConstVec<T> {
-    pub fn new() -> Self {
-        ConstVec(Rc::new(Vec::new()))
+    pub fn new() -> Rc<Self> {
+        Rc::new(ConstVec(Vec::new()))
     }
 
-    pub fn from_vec(v: Vec<T>) -> Self {
-        ConstVec(Rc::new(v))
+    pub fn from_vec(v: Vec<T>) -> Rc<Self> {
+        Rc::new(ConstVec(v))
     }
 
-    pub fn push(&self, item: T) -> Self {
-        let mut new_vec = (*self.0).clone();
+    pub fn push(self: &Rc<Self>, item: T) -> Rc<Self> {
+        let mut new_vec = self.0.clone();
         new_vec.push(item);
-        ConstVec(Rc::new(new_vec))
+        Rc::new(ConstVec(new_vec))
     }
 
     pub fn get(&self, index: usize) -> Option<&T> {
@@ -44,18 +54,30 @@ impl<T: Clone> ConstVec<T> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ConstMap<K, V>(Rc<HashMap<K, V>>);
+impl<T: fmt::Debug> fmt::Debug for ConstVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Delegate to Vec's debug implementation for standard look [...]
+        self.0.fmt(f)
+    }
+}
+
+/// A Constant Map (meant to be used as Rc<ConstMap<K, V>>)
+#[derive(Clone)]
+pub struct ConstMap<K, V>(HashMap<K, V>);
 
 impl<K: Clone + Eq + Hash, V: Clone> ConstMap<K, V> {
-    pub fn new() -> Self {
-        ConstMap(Rc::new(HashMap::new()))
+    pub fn new() -> Rc<Self> {
+        Rc::new(ConstMap(HashMap::new()))
     }
 
-    pub fn insert(&self, key: K, value: V) -> Self {
-        let mut new_map = (*self.0).clone();
+    pub fn from_map(m: HashMap<K, V>) -> Rc<Self> {
+        Rc::new(ConstMap(m))
+    }
+
+    pub fn insert(self: &Rc<Self>, key: K, value: V) -> Rc<Self> {
+        let mut new_map = self.0.clone();
         new_map.insert(key, value);
-        ConstMap(Rc::new(new_map))
+        Rc::new(ConstMap(new_map))
     }
 
     pub fn get(&self, key: &K) -> Option<&V> {
@@ -63,18 +85,29 @@ impl<K: Clone + Eq + Hash, V: Clone> ConstMap<K, V> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ConstSet<T>(Rc<HashSet<T>>);
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for ConstMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A Constant Set (meant to be used as Rc<ConstSet<T>>)
+#[derive(Clone)]
+pub struct ConstSet<T>(HashSet<T>);
 
 impl<T: Clone + Eq + Hash> ConstSet<T> {
-    pub fn new() -> Self {
-        ConstSet(Rc::new(HashSet::new()))
+    pub fn new() -> Rc<Self> {
+        Rc::new(ConstSet(HashSet::new()))
     }
 
-    pub fn insert(&self, item: T) -> Self {
-        let mut new_set = (*self.0).clone();
+    pub fn from_set(s: HashSet<T>) -> Rc<Self> {
+        Rc::new(ConstSet(s))
+    }
+
+    pub fn insert(self: &Rc<Self>, item: T) -> Rc<Self> {
+        let mut new_set = self.0.clone();
         new_set.insert(item);
-        ConstSet(Rc::new(new_set))
+        Rc::new(ConstSet(new_set))
     }
 
     pub fn contains(&self, item: &T) -> bool {
@@ -82,5 +115,11 @@ impl<T: Clone + Eq + Hash> ConstSet<T> {
     }
 }
 
+impl<T: fmt::Debug> fmt::Debug for ConstSet<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 pub mod builders;
-pub use builders::ListBuilder;
+pub use builders::{ListBuilder, MapBuilder, SetBuilder};

--- a/Code/2026/20260617_RcConst/rc-const/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/lib.rs
@@ -1,0 +1,2 @@
+﻿pub mod builders;
+pub use builders::ListBuilder;

--- a/Code/2026/20260617_RcConst/rc-const/src/lib.rs
+++ b/Code/2026/20260617_RcConst/rc-const/src/lib.rs
@@ -1,2 +1,86 @@
-﻿pub mod builders;
+﻿use std::rc::Rc;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConstStr(Rc<str>);
+
+impl ConstStr {
+    pub fn new(s: &str) -> Self {
+        ConstStr(Rc::from(s))
+    }
+}
+
+impl std::fmt::Display for ConstStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<"_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstVec<T>(Rc<Vec<T>>);
+
+impl<T: Clone> ConstVec<T> {
+    pub fn new() -> Self {
+        ConstVec(Rc::new(Vec::new()))
+    }
+
+    pub fn from_vec(v: Vec<T>) -> Self {
+        ConstVec(Rc::new(v))
+    }
+
+    pub fn push(&self, item: T) -> Self {
+        let mut new_vec = (*self.0).clone();
+        new_vec.push(item);
+        ConstVec(Rc::new(new_vec))
+    }
+
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.0.get(index)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstMap<K, V>(Rc<HashMap<K, V>>);
+
+impl<K: Clone + Eq + Hash, V: Clone> ConstMap<K, V> {
+    pub fn new() -> Self {
+        ConstMap(Rc::new(HashMap::new()))
+    }
+
+    pub fn insert(&self, key: K, value: V) -> Self {
+        let mut new_map = (*self.0).clone();
+        new_map.insert(key, value);
+        ConstMap(Rc::new(new_map))
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.0.get(key)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstSet<T>(Rc<HashSet<T>>);
+
+impl<T: Clone + Eq + Hash> ConstSet<T> {
+    pub fn new() -> Self {
+        ConstSet(Rc::new(HashSet::new()))
+    }
+
+    pub fn insert(&self, item: T) -> Self {
+        let mut new_set = (*self.0).clone();
+        new_set.insert(item);
+        ConstSet(Rc::new(new_set))
+    }
+
+    pub fn contains(&self, item: &T) -> bool {
+        self.0.contains(item)
+    }
+}
+
+pub mod builders;
 pub use builders::ListBuilder;

--- a/Code/2026/20260617_RcConst/run.cmd
+++ b/Code/2026/20260617_RcConst/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+cd /d %~dp0
+cargo run --package rc-const-demo

--- a/Code/2026/20260617_RcConst/test.cmd
+++ b/Code/2026/20260617_RcConst/test.cmd
@@ -1,0 +1,3 @@
+@echo off
+cd /d %~dp0
+cargo test --workspace


### PR DESCRIPTION
- Implemented immutable wrappers for String, Vec, Map, and Set.
- Added linked-list builders for efficient functional-style construction.
- Created a Cargo workspace with dedicated library, demo, and test crates.
- Refined Debug output for clean, indented, and human-readable serialization.
- Demonstrated cycle-free object graphs with functional update patterns.